### PR TITLE
Add credential connection tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ DB_PASSWORD="postgres-password"
 python -m pip install -r requirements.txt
 ```
 
+## Credential tests
+Scripts in `test/` verify that required credentials are configured.
+Run them individually:
+```bash
+python test/postgres_cred_conn_test.py
+python test/openai_credentials_connection_test.py
+python test/twilio_snadbox_conn_test.py
+```
+Each script loads credentials from `.env` and expects the following variables:
+DB_USER, DB_PASSWORD, OPENAI_API_KEY, TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_NUMBER, TO_NUMBER.
+
+
 ## Running the server
 1. Start the FastAPI development server:
    ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,5 @@ update==0.0.1
 urllib3==2.5.0
 uvicorn==0.35.0
 yarl==1.20.1
+
+python-dotenv==1.0.1

--- a/test/openai_credentials_connection_test.py
+++ b/test/openai_credentials_connection_test.py
@@ -1,0 +1,17 @@
+import os
+import openai
+from dotenv import load_dotenv
+
+load_dotenv()
+
+api_key = os.getenv("OPENAI_API_KEY")
+
+if api_key:
+    try:
+        client = openai.OpenAI(api_key=api_key)
+        client.models.list()
+        print("OpenAI API key is valid.")
+    except Exception as exc:
+        print(f"OpenAI API test failed: {exc}")
+else:
+    print("OPENAI_API_KEY is not set.")

--- a/test/postgres_cred_conn_test.py
+++ b/test/postgres_cred_conn_test.py
@@ -1,0 +1,28 @@
+import os
+import psycopg2
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DB_USER = os.getenv("DB_USER")
+DB_PASSWORD = os.getenv("DB_PASSWORD")
+DB_HOST = os.getenv("DB_HOST", "localhost")
+DB_PORT = os.getenv("DB_PORT", "5432")
+DB_NAME = os.getenv("DB_NAME", "postgres")
+
+if DB_USER and DB_PASSWORD:
+    try:
+        conn = psycopg2.connect(
+            user=DB_USER,
+            password=DB_PASSWORD,
+            host=DB_HOST,
+            port=DB_PORT,
+            dbname=DB_NAME,
+            connect_timeout=5,
+        )
+        conn.close()
+        print("PostgreSQL connection successful.")
+    except Exception as exc:
+        print(f"PostgreSQL connection failed: {exc}")
+else:
+    print("DB_USER or DB_PASSWORD environment variables are not set.")

--- a/test/twilio_snadbox_conn_test.py
+++ b/test/twilio_snadbox_conn_test.py
@@ -1,0 +1,25 @@
+from twilio.rest import Client
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+account_sid = os.getenv("TWILIO_ACCOUNT_SID")
+auth_token = os.getenv("TWILIO_AUTH_TOKEN")
+from_number = os.getenv("TWILIO_NUMBER")
+to_number = os.getenv("TO_NUMBER")
+
+if all([account_sid, auth_token, from_number, to_number]):
+    try:
+        client = Client(account_sid, auth_token)
+        message = client.messages.create(
+            from_=from_number,
+            content_sid='HXb5b62575e6e4ff6129ad7c8efe1f983e',
+            content_variables='{"1":"12/1","2":"3pm"}',
+            to=to_number,
+        )
+        print(message.sid)
+    except Exception as exc:
+        print(f"Twilio sandbox test failed: {exc}")
+else:
+    print("Missing Twilio environment variables.")


### PR DESCRIPTION
## Summary
- add tests verifying connections for PostgreSQL, OpenAI, and Twilio using env variables
- document how to run credential tests and required `.env` entries
- include python-dotenv in dependencies

## Testing
- `python test/postgres_cred_conn_test.py`
- `python test/openai_credentials_connection_test.py`
- `python test/twilio_snadbox_conn_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68a56e275540832ab20d6f2e840b941a