### PR TITLE
Remove unused llm logic snippet

### DIFF
--- a/app/llm_logic_test_snippet.py
+++ b/app/llm_logic_test_snippet.py
@@ -1,6 +1,0 @@
-from app.llm_logic import llm_classify_image
-
-if __name__ == "__main__":
-    # Use a local image path to force data URL path
-    path = "public/4623dd28d0a448ccbed34eb02fbed584.jpg"  # replace with an actual file saved locally
-    print(llm_classify_image(path, max_retries=1, force_detail="low"))


### PR DESCRIPTION
## Summary
- delete the unused `llm_logic_test_snippet.py` helper since `/message` already covers image classification
- remove all references to the deleted module

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc8a66323c832aa72250976e80eed0